### PR TITLE
Changed abs() to fabs() to fix compilation error on gcc 6.1.1

### DIFF
--- a/src/vmap/items/ruleitem.cpp
+++ b/src/vmap/items/ruleitem.cpp
@@ -52,7 +52,7 @@ void RuleItem::setNewEnd(QPointF& nend)
     if(m_mod & Qt::ControlModifier)
     {
         QLineF line(m_startPoint,nend);
-        if(abs(line.dx()) > abs(line.dy()))
+        if(fabs(line.dx()) > fabs(line.dy()))
         {
             nend.setY(m_startPoint.y());
         }


### PR DESCRIPTION
Fixes error
```
error: call of overloaded ‘abs(qreal)’ is ambiguous
```
when compiling on gcc 6.1.1