### PR TITLE
Fix OpenNote dialog filter not including *.htm file format

### DIFF
--- a/src/data/cleveruri.cpp
+++ b/src/data/cleveruri.cpp
@@ -261,7 +261,7 @@ QString CleverURI::getFilterForType(CleverURI::ContentType type) //static
         return QString();
         break;
     case CleverURI::TEXT:
-        return QObject::tr("Supported Text Files (%1)").arg(preferences->value("TextFileFilter","*.odt *.html *.txt").toString());
+        return QObject::tr("Supported Text Files (%1)").arg(preferences->value("TextFileFilter","*.odt *.htm *.html *.txt").toString());
         break;
     case CleverURI::SCENARIO:
         return QObject::tr("Supported Story Files (%1)").arg(preferences->value("StoryFileFilter","*.sce").toString());


### PR DESCRIPTION
The "save note" dialog saves HTML files as .htm by defautlt. The "open note" dialog has filters only for "*.html"