### PR TITLE
fix crash when removing several items in resources list

### DIFF
--- a/client/session/sessionmanager.cpp
+++ b/client/session/sessionmanager.cpp
@@ -155,7 +155,7 @@ void SessionManager::openResources(QModelIndex& index)
 void SessionManager::removeSelectedItem()
 {
     QModelIndexList list=m_view->getSelection();
-    for(int i = 0 ; i < list.size(); i++)
+    for(int i = list.size() - 1 ; i >= 0; i--)
     {
         QModelIndex index = list.at(i);
         if(!index.isValid())

--- a/client/session/sessionview.cpp
+++ b/client/session/sessionview.cpp
@@ -142,5 +142,5 @@ void SessionView::onAddChapter()
 }
 QModelIndexList SessionView::getSelection()
 {
-    return selectionModel()->selectedIndexes();
+    return selectionModel()->selectedRows();
 }


### PR DESCRIPTION
Hello,

I encountered a crash when removing 2 items from the resources list.
Here is the fix.

Weird thing : crash does not happen with release version of 1.8.2. Maybe Qt added some tests in latest versions ? I'm using Windows / Qt 5.10.1 / Qt Creator 4.6.2.